### PR TITLE
fix: upgrade depend package version

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,6 @@
     "lint"
   ],
   "dependencies": {
-    "rc-checkbox": "1.x"
+    "rc-checkbox": "2.x"
   }
 }


### PR DESCRIPTION
upgrade depend `rc-checkbox` version to run in react16